### PR TITLE
feat: publish energy cost statistics for the Energy dashboard

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -15,6 +15,10 @@ ignore = [
     "ISC001", # incompatible with formatter
 ]
 
+[lint.per-file-ignores]
+# Tests use asserts, magic values, private helpers, and naive datetimes by design.
+"tests/**" = ["ANN", "D", "DTZ", "S101", "SLF001", "PLR2004"]
+
 [lint.flake8-pytest-style]
 fixture-parentheses = false
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In November 2025, Duke Energy migrated their API authentication to use Auth0 whi
 
 The integration publishes hourly consumption as an external statistic (`duke_energy:electric_<serial>_energy_consumption`). Because it is an external statistic, Home Assistant's Energy dashboard will not accept a static price on the grid source (`Use stat_cost instead`). To track dollars, the integration can publish a paired cost statistic (`duke_energy:electric_<serial>_energy_cost`) that you select under **"Use an entity tracking the total costs"** in the Energy dashboard grid source.
 
-Duke Energy's API does not expose billed cost, so the cost is estimated from your usage and a price you configure. Open the integration's **Configure** dialog and pick a price source:
+Duke Energy's API does not expose billed cost, so the cost is estimated from your usage and a price you configure. Open the integration's **Configure** dialog, pick the meter to set up (if you have more than one, each is priced independently), and choose a price source:
 
 - **Fixed price per kWh** — a single all-in rate (derive it from a bill: total charges ÷ kWh). Tracks real bills within a couple percent for flat-rate plans.
 - **Track a price entity (dynamic)** — an entity whose state is the current price in $/kWh, e.g. an `input_number` you update when rates change, or a template sensor implementing time-of-use or seasonal rates. Backfilled hours are priced from the entity's long-term statistics when available (enable `state_class: measurement` on a template sensor to record them), falling back to the entity's current state for hours without recorded history.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ In November 2025, Duke Energy migrated their API authentication to use Auth0 whi
 8. If you already had the core integration installed, it should prompt you to re-authenticate. Otherwise, add the integration from Devices and Services.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=hunterjm&repository=ha-dukeenergy&category=integration)
+## Energy cost tracking
+
+The integration publishes hourly consumption as an external statistic (`duke_energy:electric_<serial>_energy_consumption`). Because it is an external statistic, Home Assistant's Energy dashboard will not accept a static price on the grid source (`Use stat_cost instead`). To track dollars, the integration can publish a paired cost statistic (`duke_energy:electric_<serial>_energy_cost`) that you select under **"Use an entity tracking the total costs"** in the Energy dashboard grid source.
+
+Duke Energy's API does not expose billed cost, so the cost is estimated from your usage and a price you configure. Open the integration's **Configure** dialog and pick a price source:
+
+- **Fixed price per kWh** — a single all-in rate (derive it from a bill: total charges ÷ kWh). Tracks real bills within a couple percent for flat-rate plans.
+- **Track a price entity (dynamic)** — an entity whose state is the current price in $/kWh, e.g. an `input_number` you update when rates change, or a template sensor implementing time-of-use or seasonal rates. Backfilled hours are priced from the entity's long-term statistics when available (enable `state_class: measurement` on a template sensor to record them), falling back to the entity's current state for hours without recorded history.
+
+Optionally add a **fixed monthly charge** (basic customer charge); it is spread evenly across the hours of each month.
+
+Changing these options reloads the integration, which rebuilds the statistics from scratch — cost history (up to ~3 years) is recomputed with the new settings.

--- a/custom_components/duke_energy/__init__.py
+++ b/custom_components/duke_energy/__init__.py
@@ -53,7 +53,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: DukeEnergyConfigEntry) -
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+
     return True
+
+
+async def async_update_options(
+    hass: HomeAssistant, entry: DukeEnergyConfigEntry
+) -> None:
+    """
+    Reload the entry when options change.
+
+    Unloading clears the inserted statistics, so the following setup rebuilds
+    consumption and cost history from scratch with the new price settings.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_migrate_entry(

--- a/custom_components/duke_energy/__init__.py
+++ b/custom_components/duke_energy/__init__.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aiodukeenergy import DukeEnergy
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
 
 from .api import DukeEnergyAuth
-from .const import DOMAIN
+from .const import (
+    CONF_COST_MODE,
+    CONF_FIXED_PRICE,
+    CONF_METERS,
+    CONF_MONTHLY_CHARGE,
+    CONF_PRICE_ENTITY,
+    DOMAIN,
+)
 from .coordinator import DukeEnergyConfigEntry, DukeEnergyCoordinator
 from .oauth import DukeEnergyOAuth2Implementation
 
@@ -53,21 +60,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: DukeEnergyConfigEntry) -
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
+    _migrate_flat_options(hass, entry, coordinator.meters)
+
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     return True
 
 
+def _migrate_flat_options(
+    hass: HomeAssistant,
+    entry: DukeEnergyConfigEntry,
+    meters: dict[str, dict[str, Any]],
+) -> None:
+    """Migrate pre-per-meter flat cost options onto every meter."""
+    options = entry.options
+    if CONF_METERS in options or CONF_COST_MODE not in options or not meters:
+        return
+    flat = {
+        key: options[key]
+        for key in (
+            CONF_COST_MODE,
+            CONF_FIXED_PRICE,
+            CONF_PRICE_ENTITY,
+            CONF_MONTHLY_CHARGE,
+        )
+        if key in options
+    }
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_METERS: {serial: dict(flat) for serial in meters}}
+    )
+
+
 async def async_update_options(
-    hass: HomeAssistant, entry: DukeEnergyConfigEntry
+    _hass: HomeAssistant, entry: DukeEnergyConfigEntry
 ) -> None:
     """
-    Reload the entry when options change.
+    Recompute cost statistics locally when options change.
 
-    Unloading clears the inserted statistics, so the following setup rebuilds
-    consumption and cost history from scratch with the new price settings.
+    Cost is derived from the stored consumption statistic, so a price change is a
+    local recompute -- no entry reload, no Duke API calls, and consumption
+    history is left untouched.
     """
-    await hass.config_entries.async_reload(entry.entry_id)
+    await entry.runtime_data.async_rebuild_costs()
 
 
 async def async_migrate_entry(

--- a/custom_components/duke_energy/config_flow.py
+++ b/custom_components/duke_energy/config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
+    SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -29,6 +30,7 @@ from homeassistant.helpers.selector import (
 from .const import (
     CONF_COST_MODE,
     CONF_FIXED_PRICE,
+    CONF_METERS,
     CONF_MONTHLY_CHARGE,
     CONF_PRICE_ENTITY,
     COST_MODE_ENTITY,
@@ -116,15 +118,50 @@ class DukeEnergyOAuth2FlowHandler(
         return self.async_create_entry(title=email or user_id, data=data)
 
 
+CONF_METER = "meter"
+
+
 class DukeEnergyOptionsFlowHandler(OptionsFlow):
-    """Handle Duke Energy options for cost statistics."""
+    """Configure the cost price source for each meter."""
+
+    def __init__(self) -> None:
+        """Initialize the options flow."""
+        self._serial: str = ""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Manage the cost tracking options."""
-        errors: dict[str, str] = {}
+        """Pick a meter to configure, skipping the picker for a single meter."""
+        meters = self._meters()
+        if not meters:
+            return self.async_abort(reason="no_meters")
+        if user_input is not None:
+            self._serial = user_input[CONF_METER]
+            return await self.async_step_meter()
+        if len(meters) == 1:
+            self._serial = next(iter(meters))
+            return await self.async_step_meter()
 
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_METER): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            SelectOptionDict(value=serial, label=label)
+                            for serial, label in meters.items()
+                        ],
+                        mode=SelectSelectorMode.LIST,
+                    )
+                )
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)
+
+    async def async_step_meter(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Configure and save the price source for the selected meter."""
+        errors: dict[str, str] = {}
         if user_input is not None:
             cost_mode = user_input[CONF_COST_MODE]
             if cost_mode == COST_MODE_FIXED and not user_input.get(CONF_FIXED_PRICE):
@@ -134,14 +171,43 @@ class DukeEnergyOptionsFlowHandler(OptionsFlow):
             ):
                 errors[CONF_PRICE_ENTITY] = "price_entity_required"
             if not errors:
-                return self.async_create_entry(title="", data=user_input)
+                meters = dict(self.config_entry.options.get(CONF_METERS, {}))
+                meters[self._serial] = user_input
+                return self.async_create_entry(title="", data={CONF_METERS: meters})
 
-        options = user_input or self.config_entry.options
-        schema = vol.Schema(
+        current = user_input or self.config_entry.options.get(CONF_METERS, {}).get(
+            self._serial, {}
+        )
+        return self.async_show_form(
+            step_id="meter",
+            data_schema=self._meter_schema(current),
+            errors=errors,
+            description_placeholders={"meter": self._meters().get(self._serial, "")},
+        )
+
+    def _meters(self) -> dict[str, str]:
+        """Map each configurable meter's serial to a display label."""
+        coordinator = self.config_entry.runtime_data
+        meters = coordinator.meters if coordinator else {}
+        if meters:
+            return {
+                serial: f"{meter['serviceType'].capitalize()} meter {serial}"
+                for serial, meter in meters.items()
+            }
+        # Entry not loaded: fall back to meters that already have saved options.
+        return {
+            serial: f"Meter {serial}"
+            for serial in self.config_entry.options.get(CONF_METERS, {})
+        }
+
+    @staticmethod
+    def _meter_schema(current: Mapping[str, Any]) -> vol.Schema:
+        """Build the per-meter cost options schema, defaulted to current values."""
+        return vol.Schema(
             {
                 vol.Required(
                     CONF_COST_MODE,
-                    default=options.get(CONF_COST_MODE, COST_MODE_NONE),
+                    default=current.get(CONF_COST_MODE, COST_MODE_NONE),
                 ): SelectSelector(
                     SelectSelectorConfig(
                         options=COST_MODES,
@@ -151,9 +217,7 @@ class DukeEnergyOptionsFlowHandler(OptionsFlow):
                 ),
                 vol.Optional(
                     CONF_FIXED_PRICE,
-                    description={
-                        "suggested_value": options.get(CONF_FIXED_PRICE),
-                    },
+                    description={"suggested_value": current.get(CONF_FIXED_PRICE)},
                 ): NumberSelector(
                     NumberSelectorConfig(
                         min=0,
@@ -164,17 +228,13 @@ class DukeEnergyOptionsFlowHandler(OptionsFlow):
                 ),
                 vol.Optional(
                     CONF_PRICE_ENTITY,
-                    description={
-                        "suggested_value": options.get(CONF_PRICE_ENTITY),
-                    },
+                    description={"suggested_value": current.get(CONF_PRICE_ENTITY)},
                 ): EntitySelector(
                     EntitySelectorConfig(domain=["sensor", "input_number", "number"])
                 ),
                 vol.Optional(
                     CONF_MONTHLY_CHARGE,
-                    description={
-                        "suggested_value": options.get(CONF_MONTHLY_CHARGE),
-                    },
+                    description={"suggested_value": current.get(CONF_MONTHLY_CHARGE)},
                 ): NumberSelector(
                     NumberSelectorConfig(
                         min=0,
@@ -185,5 +245,3 @@ class DukeEnergyOptionsFlowHandler(OptionsFlow):
                 ),
             }
         )
-
-        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/duke_energy/config_flow.py
+++ b/custom_components/duke_energy/config_flow.py
@@ -175,14 +175,18 @@ class DukeEnergyOptionsFlowHandler(OptionsFlow):
                 meters[self._serial] = user_input
                 return self.async_create_entry(title="", data={CONF_METERS: meters})
 
+        unit = self._meter_unit(self._serial)
         current = user_input or self.config_entry.options.get(CONF_METERS, {}).get(
             self._serial, {}
         )
         return self.async_show_form(
             step_id="meter",
-            data_schema=self._meter_schema(current),
+            data_schema=self._meter_schema(current, unit),
             errors=errors,
-            description_placeholders={"meter": self._meters().get(self._serial, "")},
+            description_placeholders={
+                "meter": self._meters().get(self._serial, ""),
+                "unit": unit,
+            },
         )
 
     def _meters(self) -> dict[str, str]:
@@ -200,8 +204,15 @@ class DukeEnergyOptionsFlowHandler(OptionsFlow):
             for serial in self.config_entry.options.get(CONF_METERS, {})
         }
 
+    def _meter_unit(self, serial: str) -> str:
+        """Return the price unit for a meter (kWh for electric, CCF for gas)."""
+        coordinator = self.config_entry.runtime_data
+        meters = coordinator.meters if coordinator else {}
+        service_type = meters.get(serial, {}).get("serviceType")
+        return "CCF" if service_type == "GAS" else "kWh"
+
     @staticmethod
-    def _meter_schema(current: Mapping[str, Any]) -> vol.Schema:
+    def _meter_schema(current: Mapping[str, Any], unit: str) -> vol.Schema:
         """Build the per-meter cost options schema, defaulted to current values."""
         return vol.Schema(
             {
@@ -223,7 +234,7 @@ class DukeEnergyOptionsFlowHandler(OptionsFlow):
                         min=0,
                         step="any",
                         mode=NumberSelectorMode.BOX,
-                        unit_of_measurement="$/kWh",
+                        unit_of_measurement=f"$/{unit}",
                     )
                 ),
                 vol.Optional(

--- a/custom_components/duke_energy/config_flow.py
+++ b/custom_components/duke_energy/config_flow.py
@@ -6,10 +6,37 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import jwt
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+import voluptuous as vol
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigEntry,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN
+from .const import (
+    CONF_COST_MODE,
+    CONF_FIXED_PRICE,
+    CONF_MONTHLY_CHARGE,
+    CONF_PRICE_ENTITY,
+    COST_MODE_ENTITY,
+    COST_MODE_FIXED,
+    COST_MODE_NONE,
+    COST_MODES,
+    DOMAIN,
+)
 from .oauth import DukeEnergyOAuth2Implementation
 
 if TYPE_CHECKING:
@@ -33,6 +60,14 @@ class DukeEnergyOAuth2FlowHandler(
     def logger(self) -> logging.Logger:
         """Return logger."""
         return _LOGGER
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        _config_entry: ConfigEntry,
+    ) -> DukeEnergyOptionsFlowHandler:
+        """Create the options flow."""
+        return DukeEnergyOptionsFlowHandler()
 
     async def async_step_pick_implementation(
         self, _: dict[str, Any] | None = None
@@ -79,3 +114,76 @@ class DukeEnergyOAuth2FlowHandler(
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(title=email or user_id, data=data)
+
+
+class DukeEnergyOptionsFlowHandler(OptionsFlow):
+    """Handle Duke Energy options for cost statistics."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the cost tracking options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            cost_mode = user_input[CONF_COST_MODE]
+            if cost_mode == COST_MODE_FIXED and not user_input.get(CONF_FIXED_PRICE):
+                errors[CONF_FIXED_PRICE] = "fixed_price_required"
+            elif cost_mode == COST_MODE_ENTITY and not user_input.get(
+                CONF_PRICE_ENTITY
+            ):
+                errors[CONF_PRICE_ENTITY] = "price_entity_required"
+            if not errors:
+                return self.async_create_entry(title="", data=user_input)
+
+        options = user_input or self.config_entry.options
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_COST_MODE,
+                    default=options.get(CONF_COST_MODE, COST_MODE_NONE),
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=COST_MODES,
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key=CONF_COST_MODE,
+                    )
+                ),
+                vol.Optional(
+                    CONF_FIXED_PRICE,
+                    description={
+                        "suggested_value": options.get(CONF_FIXED_PRICE),
+                    },
+                ): NumberSelector(
+                    NumberSelectorConfig(
+                        min=0,
+                        step="any",
+                        mode=NumberSelectorMode.BOX,
+                        unit_of_measurement="$/kWh",
+                    )
+                ),
+                vol.Optional(
+                    CONF_PRICE_ENTITY,
+                    description={
+                        "suggested_value": options.get(CONF_PRICE_ENTITY),
+                    },
+                ): EntitySelector(
+                    EntitySelectorConfig(domain=["sensor", "input_number", "number"])
+                ),
+                vol.Optional(
+                    CONF_MONTHLY_CHARGE,
+                    description={
+                        "suggested_value": options.get(CONF_MONTHLY_CHARGE),
+                    },
+                ): NumberSelector(
+                    NumberSelectorConfig(
+                        min=0,
+                        step="any",
+                        mode=NumberSelectorMode.BOX,
+                        unit_of_measurement="$/month",
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/duke_energy/const.py
+++ b/custom_components/duke_energy/const.py
@@ -18,7 +18,10 @@ MOBILE_REDIRECT_URI = "https://login.duke-energy.com/ios/com.duke-energy.app/cal
 
 # Options for cost statistics.
 # The Duke Energy API does not expose per-interval cost, so cost is derived
-# from consumption using a user-configured price source.
+# from consumption using a user-configured price source. Options are stored
+# per meter under CONF_METERS so meters on different rates can be priced apart.
+CONF_METERS = "meters"
+
 CONF_COST_MODE = "cost_mode"
 COST_MODE_NONE = "none"
 COST_MODE_FIXED = "fixed"

--- a/custom_components/duke_energy/const.py
+++ b/custom_components/duke_energy/const.py
@@ -15,3 +15,16 @@ AUTH0_CLIENT = "eyJuYW1lIjoiQXV0aDAuc3dpZnQiLCJlbnYiOnsiaU9TIjoiMjYuMiIsInN3aWZ0
 
 # Mobile app redirect URI - required by Duke Energy Auth0 config
 MOBILE_REDIRECT_URI = "https://login.duke-energy.com/ios/com.duke-energy.app/callback"
+
+# Options for cost statistics.
+# The Duke Energy API does not expose per-interval cost, so cost is derived
+# from consumption using a user-configured price source.
+CONF_COST_MODE = "cost_mode"
+COST_MODE_NONE = "none"
+COST_MODE_FIXED = "fixed"
+COST_MODE_ENTITY = "entity"
+COST_MODES = [COST_MODE_NONE, COST_MODE_FIXED, COST_MODE_ENTITY]
+
+CONF_FIXED_PRICE = "fixed_price"
+CONF_PRICE_ENTITY = "price_entity"
+CONF_MONTHLY_CHARGE = "monthly_charge"

--- a/custom_components/duke_energy/coordinator.py
+++ b/custom_components/duke_energy/coordinator.py
@@ -1,6 +1,5 @@
 """Coordinator to handle Duke Energy connections."""
 
-import calendar
 import logging
 from bisect import bisect_right
 from collections.abc import Callable, Mapping
@@ -50,6 +49,11 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 _SUPPORTED_METER_TYPES = ("ELECTRIC",)
+
+# Duke Energy service areas are all in America/New_York.
+_TIMEZONE = "America/New_York"
+# Re-fetch/recompute this far before a resume point so corrected hours are rewritten.
+_LOOKBACK = timedelta(days=30)
 
 type DukeEnergyConfigEntry = ConfigEntry[DukeEnergyCoordinator]
 
@@ -119,175 +123,239 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
     async def _async_insert_meter_statistics(
         self, serial_number: str, meter: dict[str, Any]
     ) -> None:
-        """Insert consumption and (if enabled) cost statistics for a meter."""
-        id_prefix = f"{meter['serviceType'].lower()}_{serial_number}"
-        consumption_statistic_id = f"{DOMAIN}:{id_prefix}_energy_consumption"
-        cost_statistic_id = f"{DOMAIN}:{id_prefix}_energy_cost"
+        """Insert a meter's consumption (from the API) and cost (derived locally)."""
+        consumption_id, cost_id = self._meter_statistic_ids(serial_number, meter)
+        self._statistic_ids.add(consumption_id)
+        await self._async_update_consumption(serial_number, meter)
+
         meter_options = self._meter_options(serial_number)
-        cost_enabled = (
-            meter_options.get(CONF_COST_MODE, COST_MODE_NONE) != COST_MODE_NONE
-        )
-        self._statistic_ids.add(consumption_statistic_id)
-        if cost_enabled:
-            self._statistic_ids.add(cost_statistic_id)
-        _LOGGER.debug("Updating Statistics for %s", consumption_statistic_id)
+        if meter_options.get(CONF_COST_MODE, COST_MODE_NONE) != COST_MODE_NONE:
+            self._statistic_ids.add(cost_id)
+            await self._async_update_cost(serial_number, meter, meter_options)
 
-        statistic_ids = {consumption_statistic_id}
-        if cost_enabled:
-            statistic_ids.add(cost_statistic_id)
+    async def async_rebuild_costs(self) -> None:
+        """
+        Recompute cost from stored consumption after an options change.
 
-        # Start time of each statistic's newest row; None means it has no
-        # history yet and must be backfilled from scratch.
-        consumption_resume = await self._async_last_stat_start(consumption_statistic_id)
-        cost_resume = (
-            await self._async_last_stat_start(cost_statistic_id)
-            if cost_enabled
-            else None
-        )
+        Cost is derived from the consumption statistic, so changing a price is a
+        local recompute -- no Duke API calls and no consumption rebuild.
+        """
+        for serial_number, meter in self.meters.items():
+            _, cost_id = self._meter_statistic_ids(serial_number, meter)
+            get_instance(self.hass).async_clear_statistics([cost_id])
+            meter_options = self._meter_options(serial_number)
+            if meter_options.get(CONF_COST_MODE, COST_MODE_NONE) == COST_MODE_NONE:
+                self._statistic_ids.discard(cost_id)
+                continue
+            self._statistic_ids.add(cost_id)
+            await self._async_update_cost(
+                serial_number, meter, meter_options, full=True
+            )
 
-        # Fetch usage from the earliest resume point so a cost statistic that
-        # lagged behind consumption (e.g. the price entity was unavailable) has
-        # those hours re-fetched and can catch up instead of stalling forever.
-        resume_points = [consumption_resume]
-        if cost_enabled:
-            resume_points.append(cost_resume)
-        window_from = (
-            None
-            if None in resume_points
-            else min(point for point in resume_points if point is not None)
-        )
-
-        usage = await self._async_get_energy_usage(meter, window_from)
-        if window_from is not None and not usage:
-            _LOGGER.debug("No recent usage data. Skipping update")
+    async def _async_update_consumption(
+        self, serial_number: str, meter: dict[str, Any]
+    ) -> None:
+        """Insert consumption statistics from the Duke API (incremental)."""
+        consumption_id, _ = self._meter_statistic_ids(serial_number, meter)
+        resume = await self._async_last_stat_start(consumption_id)
+        usage = await self._async_get_energy_usage(meter, resume)
+        if resume is not None and not usage:
+            _LOGGER.debug("No recent usage for %s. Skipping update", consumption_id)
             return
 
-        # Each baseline is the (sum, start time) to resume statistics from.
-        consumption_baseline: tuple[float, float | None] = (0.0, None)
-        cost_baseline: tuple[float, float | None] = (0.0, None)
-        if window_from is not None:
+        baseline: tuple[float, float | None] = (0.0, None)
+        if resume is not None:
             stats = await get_instance(self.hass).async_add_executor_job(
                 statistics_during_period,
                 self.hass,
                 min(usage.keys()),
                 None,
-                statistic_ids,
+                {consumption_id},
                 "hour",
                 None,
                 {"sum"},
             )
-            consumption_baseline = self._resume_baseline(
-                stats.get(consumption_statistic_id)
-            )
-            if cost_enabled:
-                cost_baseline = self._resume_baseline(stats.get(cost_statistic_id))
+            baseline = self._resume_baseline(stats.get(consumption_id), resume)
 
-        price_at: Callable[[datetime], float | None] | None = None
-        if cost_enabled and usage:
-            price_at = await self._async_build_price_lookup(
-                meter_options, min(usage.keys()), max(usage.keys())
-            )
-
-        consumption_statistics, cost_statistics = self._build_statistic_rows(
-            usage, consumption_baseline, cost_baseline, price_at, meter_options
+        rows = self._build_consumption_rows(
+            {start: data["energy"] for start, data in usage.items()}, baseline
+        )
+        _LOGGER.debug("Adding %s consumption stats for %s", len(rows), consumption_id)
+        async_add_external_statistics(
+            self.hass, self._energy_metadata(serial_number, meter), rows
         )
 
-        name_prefix = f"Duke Energy {meter['serviceType'].capitalize()} {serial_number}"
-        consumption_metadata = StatisticMetaData(
+    async def _async_update_cost(
+        self,
+        serial_number: str,
+        meter: dict[str, Any],
+        meter_options: Mapping[str, Any],
+        *,
+        full: bool = False,
+    ) -> None:
+        """
+        Insert cost statistics derived from the stored consumption statistic.
+
+        Reads the per-hour energy already recorded for consumption and prices it
+        locally, so cost never triggers its own Duke API fetch. ``full`` rebuilds
+        the entire history (after an options change); otherwise it resumes.
+        """
+        consumption_id, cost_id = self._meter_statistic_ids(serial_number, meter)
+        resume = None if full else await self._async_last_stat_start(cost_id)
+        energy = await self._async_consumption_energy(consumption_id, resume)
+        if not energy:
+            return
+
+        baseline: tuple[float, float | None] = (0.0, None)
+        if resume is not None:
+            stats = await get_instance(self.hass).async_add_executor_job(
+                statistics_during_period,
+                self.hass,
+                min(energy),
+                None,
+                {cost_id},
+                "hour",
+                None,
+                {"sum"},
+            )
+            baseline = self._resume_baseline(stats.get(cost_id), resume)
+
+        price_at = await self._async_build_price_lookup(
+            meter_options, min(energy), max(energy)
+        )
+        if price_at is None:
+            return
+        rows = self._build_cost_rows(energy, baseline, price_at, meter_options)
+        if not rows:
+            return
+        _LOGGER.debug("Adding %s cost stats for %s", len(rows), cost_id)
+        async_add_external_statistics(
+            self.hass, self._cost_metadata(serial_number, meter), rows
+        )
+
+    @staticmethod
+    def _meter_statistic_ids(
+        serial_number: str, meter: dict[str, Any]
+    ) -> tuple[str, str]:
+        """Return the (consumption, cost) external statistic ids for a meter."""
+        id_prefix = f"{meter['serviceType'].lower()}_{serial_number}"
+        return (
+            f"{DOMAIN}:{id_prefix}_energy_consumption",
+            f"{DOMAIN}:{id_prefix}_energy_cost",
+        )
+
+    def _energy_metadata(
+        self, serial_number: str, meter: dict[str, Any]
+    ) -> StatisticMetaData:
+        """Build consumption statistic metadata for a meter."""
+        consumption_id, _ = self._meter_statistic_ids(serial_number, meter)
+        return StatisticMetaData(
             mean_type=StatisticMeanType.NONE,
             has_sum=True,
-            name=f"{name_prefix} Consumption",
+            name=(
+                f"Duke Energy {meter['serviceType'].capitalize()} "
+                f"{serial_number} Consumption"
+            ),
             source=DOMAIN,
-            statistic_id=consumption_statistic_id,
+            statistic_id=consumption_id,
             unit_class=EnergyConverter.UNIT_CLASS,
             unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR
             if meter["serviceType"] == "ELECTRIC"
             else UnitOfVolume.CENTUM_CUBIC_FEET,
         )
 
-        _LOGGER.debug(
-            "Adding %s statistics for %s",
-            len(consumption_statistics),
-            consumption_statistic_id,
-        )
-        async_add_external_statistics(
-            self.hass, consumption_metadata, consumption_statistics
+    def _cost_metadata(
+        self, serial_number: str, meter: dict[str, Any]
+    ) -> StatisticMetaData:
+        """Build cost statistic metadata for a meter."""
+        _, cost_id = self._meter_statistic_ids(serial_number, meter)
+        return StatisticMetaData(
+            mean_type=StatisticMeanType.NONE,
+            has_sum=True,
+            name=(
+                f"Duke Energy {meter['serviceType'].capitalize()} {serial_number} Cost"
+            ),
+            source=DOMAIN,
+            statistic_id=cost_id,
+            unit_class=None,
+            unit_of_measurement=None,
         )
 
-        if cost_enabled and cost_statistics:
-            cost_metadata = StatisticMetaData(
-                mean_type=StatisticMeanType.NONE,
-                has_sum=True,
-                name=f"{name_prefix} Cost",
-                source=DOMAIN,
-                statistic_id=cost_statistic_id,
-                unit_class=None,
-                unit_of_measurement=None,
-            )
-            _LOGGER.debug(
-                "Adding %s statistics for %s",
-                len(cost_statistics),
-                cost_statistic_id,
-            )
-            async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
+    @staticmethod
+    def _build_consumption_rows(
+        energy_by_hour: dict[datetime, float],
+        baseline: tuple[float, float | None],
+    ) -> list[StatisticData]:
+        """Build cumulative consumption rows for hours after the baseline."""
+        total, resume = baseline
+        rows: list[StatisticData] = []
+        for start, energy in energy_by_hour.items():
+            if resume is not None and start.timestamp() <= resume:
+                continue
+            total += energy
+            rows.append(StatisticData(start=start, state=energy, sum=total))
+        return rows
 
-    def _build_statistic_rows(
+    def _build_cost_rows(
         self,
-        usage: dict[datetime, dict[str, float | int]],
-        consumption_baseline: tuple[float, float | None],
-        cost_baseline: tuple[float, float | None],
-        price_at: Callable[[datetime], float | None] | None,
+        energy_by_hour: dict[datetime, float],
+        baseline: tuple[float, float | None],
+        price_at: Callable[[datetime], float | None],
         meter_options: Mapping[str, Any],
-    ) -> tuple[list[StatisticData], list[StatisticData]]:
+    ) -> list[StatisticData]:
         """
-        Build consumption and cost statistic rows from usage data.
+        Build cumulative cost rows from per-hour energy.
 
-        Each baseline is the (sum, start time) to resume from. Consumption and
-        cost carry independent resume times so a cost statistic that lags
-        behind (price entity unavailable, or cost enabled after consumption
-        already existed) can catch up on later refreshes.
+        Stops at the first hour without a resolvable price so the sum stays
+        contiguous; a later refresh resumes there once a price is available.
         """
-        consumption_sum, last_stats_time = consumption_baseline
-        cost_sum, cost_last_stats_time = cost_baseline
-        consumption_statistics: list[StatisticData] = []
-        cost_statistics: list[StatisticData] = []
-        cost_incomplete = False
-
-        for start, data in usage.items():
-            energy = data["energy"]
-            if last_stats_time is None or start.timestamp() > last_stats_time:
-                consumption_sum += energy
-                consumption_statistics.append(
-                    StatisticData(start=start, state=energy, sum=consumption_sum)
-                )
-
-            if (
-                price_at is None
-                or cost_incomplete
-                or (
-                    cost_last_stats_time is not None
-                    and start.timestamp() <= cost_last_stats_time
-                )
-            ):
+        total, resume = baseline
+        rows: list[StatisticData] = []
+        for start, energy in energy_by_hour.items():
+            if resume is not None and start.timestamp() <= resume:
                 continue
             price = price_at(start)
             if price is None:
-                # Stop instead of skipping so the sum stays contiguous;
-                # the next refresh retries these hours.
-                cost_incomplete = True
-                _LOGGER.warning(
-                    "No price available for %s; deferring cost statistics", start
-                )
-                continue
-            cost_state = energy * price + self._hourly_fixed_charge(
-                meter_options, start
-            )
-            cost_sum += cost_state
-            cost_statistics.append(
-                StatisticData(start=start, state=cost_state, sum=cost_sum)
-            )
+                _LOGGER.debug("No price available for %s; deferring cost", start)
+                break
+            charge = energy * price + self._hourly_fixed_charge(meter_options, start)
+            total += charge
+            rows.append(StatisticData(start=start, state=charge, sum=total))
+        return rows
 
-        return consumption_statistics, cost_statistics
+    async def _async_consumption_energy(
+        self, consumption_id: str, resume: float | None
+    ) -> dict[datetime, float]:
+        """
+        Return per-hour energy from the stored consumption statistic.
+
+        Reads locally recorded data (no Duke API call). When resuming it starts a
+        lookback before the resume point so corrected hours are recomputed; a
+        full rebuild (resume is None) reads the whole history.
+        """
+        tz = await dt_util.async_get_time_zone(_TIMEZONE)
+        start = (
+            dt_util.utc_from_timestamp(resume) - _LOOKBACK
+            if resume is not None
+            else dt_util.utc_from_timestamp(0)
+        )
+        stats = await get_instance(self.hass).async_add_executor_job(
+            statistics_during_period,
+            self.hass,
+            start,
+            None,
+            {consumption_id},
+            "hour",
+            None,
+            {"state"},
+        )
+        return {
+            dt_util.utc_from_timestamp(row["start"]).astimezone(tz): cast(
+                "float", row["state"]
+            )
+            for row in stats.get(consumption_id, [])
+            if row.get("state") is not None
+        }
 
     async def _async_last_stat_start(self, statistic_id: str) -> float | None:
         """Return the start time of a statistic's newest row, or None if empty."""
@@ -304,16 +372,23 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
         return None
 
     @staticmethod
-    def _resume_baseline(rows: list[Any] | None) -> tuple[float, float | None]:
+    def _resume_baseline(
+        rows: list[Any] | None, resume: float | None
+    ) -> tuple[float, float | None]:
         """
-        Return the (sum, start) to resume from: the oldest row in the window.
+        Return the (sum, start) to resume a statistic from.
 
-        Resuming from the window start lets the 30-day usage lookback rewrite
-        recently corrected hours while keeping the running sum contiguous.
+        Anchors to roughly the lookback window before the statistic's own newest
+        row, so recently corrected hours are rewritten without dragging the
+        resume point back to the (possibly older) start of the query window.
         """
-        if rows:
-            return cast("float", rows[0]["sum"]), rows[0]["start"]
-        return 0.0, None
+        if not rows or resume is None:
+            return 0.0, None
+        threshold = resume - _LOOKBACK.total_seconds()
+        for row in rows:
+            if row["start"] >= threshold:
+                return cast("float", row["sum"]), row["start"]
+        return cast("float", rows[-1]["sum"]), rows[-1]["start"]
 
     def _meter_options(self, serial_number: str) -> Mapping[str, Any]:
         """
@@ -407,12 +482,18 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
     def _hourly_fixed_charge(
         self, meter_options: Mapping[str, Any], start: datetime
     ) -> float:
-        """Return the fixed monthly charge amortized over the hours of a month."""
+        """Return the monthly charge amortized over the actual hours of the month."""
         monthly_charge = meter_options.get(CONF_MONTHLY_CHARGE)
         if not monthly_charge:
             return 0.0
-        days_in_month = calendar.monthrange(start.year, start.month)[1]
-        return float(monthly_charge) / (days_in_month * 24)
+        month_start = start.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        years, month_index = divmod(month_start.month, 12)
+        next_month = month_start.replace(
+            year=month_start.year + years, month=month_index + 1
+        )
+        # timestamp() spans real time, so DST-transition months get 23/25h days.
+        hours = (next_month.timestamp() - month_start.timestamp()) / 3600
+        return float(monthly_charge) / hours
 
     async def _async_get_energy_usage(
         self, meter: dict[str, Any], start_time: float | None = None
@@ -429,8 +510,8 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
         # All of Duke Energy Service Areas are currently in America/New_York timezone
         # May need to re-think this if that ever changes and determine timezone based
         # on the service address somehow.
-        tz = await dt_util.async_get_time_zone("America/New_York")
-        lookback = timedelta(days=30)
+        tz = await dt_util.async_get_time_zone(_TIMEZONE)
+        lookback = _LOOKBACK
         one = timedelta(days=1)
         if start_time is None:
             # Max 3 years of data

--- a/custom_components/duke_energy/coordinator.py
+++ b/custom_components/duke_energy/coordinator.py
@@ -1,6 +1,9 @@
 """Coordinator to handle Duke Energy connections."""
 
+import calendar
 import logging
+from bisect import bisect_right
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any, cast
 
@@ -20,14 +23,28 @@ from homeassistant.components.recorder.statistics import (
     statistics_during_period,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfEnergy, UnitOfVolume
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfEnergy,
+    UnitOfVolume,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import EnergyConverter
 
-from .const import DOMAIN
+from .const import (
+    CONF_COST_MODE,
+    CONF_FIXED_PRICE,
+    CONF_MONTHLY_CHARGE,
+    CONF_PRICE_ENTITY,
+    COST_MODE_ENTITY,
+    COST_MODE_FIXED,
+    COST_MODE_NONE,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,87 +109,294 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
                 )
                 continue
 
-            id_prefix = f"{meter['serviceType'].lower()}_{serial_number}"
-            consumption_statistic_id = f"{DOMAIN}:{id_prefix}_energy_consumption"
-            self._statistic_ids.add(consumption_statistic_id)
-            _LOGGER.debug(
-                "Updating Statistics for %s",
-                consumption_statistic_id,
-            )
+            await self._async_insert_meter_statistics(serial_number, meter)
 
-            last_stat = await get_instance(self.hass).async_add_executor_job(
-                get_last_statistics,
-                self.hass,
-                1,
-                consumption_statistic_id,
-                True,  # noqa: FBT003
-                set(),
+    async def _async_insert_meter_statistics(
+        self, serial_number: str, meter: dict[str, Any]
+    ) -> None:
+        """Insert consumption and (if enabled) cost statistics for a meter."""
+        id_prefix = f"{meter['serviceType'].lower()}_{serial_number}"
+        consumption_statistic_id = f"{DOMAIN}:{id_prefix}_energy_consumption"
+        cost_statistic_id = f"{DOMAIN}:{id_prefix}_energy_cost"
+        cost_enabled = (
+            self.config_entry.options.get(CONF_COST_MODE, COST_MODE_NONE)
+            != COST_MODE_NONE
+        )
+        self._statistic_ids.add(consumption_statistic_id)
+        if cost_enabled:
+            self._statistic_ids.add(cost_statistic_id)
+        _LOGGER.debug(
+            "Updating Statistics for %s",
+            consumption_statistic_id,
+        )
+
+        statistic_ids = {consumption_statistic_id}
+        if cost_enabled:
+            statistic_ids.add(cost_statistic_id)
+
+        last_stat = await get_instance(self.hass).async_add_executor_job(
+            get_last_statistics,
+            self.hass,
+            1,
+            consumption_statistic_id,
+            True,  # noqa: FBT003
+            set(),
+        )
+        # Each baseline is the (sum, start time) to resume statistics from.
+        cost_baseline: tuple[float, float | None] = (0.0, None)
+        if not last_stat:
+            _LOGGER.debug("Updating statistic for the first time")
+            usage = await self._async_get_energy_usage(meter)
+            consumption_baseline: tuple[float, float | None] = (0.0, None)
+        else:
+            usage = await self._async_get_energy_usage(
+                meter,
+                last_stat[consumption_statistic_id][0]["start"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
             )
-            if not last_stat:
-                _LOGGER.debug("Updating statistic for the first time")
-                usage = await self._async_get_energy_usage(meter)
-                consumption_sum = 0.0
-                last_stats_time = None
-            else:
-                usage = await self._async_get_energy_usage(
-                    meter,
-                    last_stat[consumption_statistic_id][0]["start"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
-                )
-                if not usage:
-                    _LOGGER.debug("No recent usage data. Skipping update")
-                    continue
-                stats = await get_instance(self.hass).async_add_executor_job(
-                    statistics_during_period,
-                    self.hass,
-                    min(usage.keys()),
-                    None,
-                    {consumption_statistic_id},
-                    "hour",
-                    None,
-                    {"sum"},
-                )
-                consumption_sum = cast(
+            if not usage:
+                _LOGGER.debug("No recent usage data. Skipping update")
+                return
+            stats = await get_instance(self.hass).async_add_executor_job(
+                statistics_during_period,
+                self.hass,
+                min(usage.keys()),
+                None,
+                statistic_ids,
+                "hour",
+                None,
+                {"sum"},
+            )
+            consumption_baseline = (
+                cast(
                     "float",
                     stats[consumption_statistic_id][0]["sum"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
-                )
-                last_stats_time = stats[consumption_statistic_id][0]["start"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
-
-            consumption_statistics = []
-
-            for start, data in usage.items():
-                if last_stats_time is not None and start.timestamp() <= last_stats_time:
-                    continue
-                consumption_sum += data["energy"]
-
-                consumption_statistics.append(
-                    StatisticData(
-                        start=start, state=data["energy"], sum=consumption_sum
-                    )
-                )
-
-            name_prefix = (
-                f"Duke Energy {meter['serviceType'].capitalize()} {serial_number}"
+                ),
+                stats[consumption_statistic_id][0]["start"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
             )
-            consumption_metadata = StatisticMetaData(
+            if cost_enabled:
+                cost_baseline = await self._async_get_cost_baseline(
+                    cost_statistic_id, stats.get(cost_statistic_id)
+                )
+
+        price_at: Callable[[datetime], float | None] | None = None
+        if cost_enabled and usage:
+            price_at = await self._async_build_price_lookup(
+                min(usage.keys()), max(usage.keys())
+            )
+
+        consumption_statistics, cost_statistics = self._build_statistic_rows(
+            usage, consumption_baseline, cost_baseline, price_at
+        )
+
+        name_prefix = f"Duke Energy {meter['serviceType'].capitalize()} {serial_number}"
+        consumption_metadata = StatisticMetaData(
+            mean_type=StatisticMeanType.NONE,
+            has_sum=True,
+            name=f"{name_prefix} Consumption",
+            source=DOMAIN,
+            statistic_id=consumption_statistic_id,
+            unit_class=EnergyConverter.UNIT_CLASS,
+            unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR
+            if meter["serviceType"] == "ELECTRIC"
+            else UnitOfVolume.CENTUM_CUBIC_FEET,
+        )
+
+        _LOGGER.debug(
+            "Adding %s statistics for %s",
+            len(consumption_statistics),
+            consumption_statistic_id,
+        )
+        async_add_external_statistics(
+            self.hass, consumption_metadata, consumption_statistics
+        )
+
+        if cost_enabled and cost_statistics:
+            cost_metadata = StatisticMetaData(
                 mean_type=StatisticMeanType.NONE,
                 has_sum=True,
-                name=f"{name_prefix} Consumption",
+                name=f"{name_prefix} Cost",
                 source=DOMAIN,
-                statistic_id=consumption_statistic_id,
-                unit_class=EnergyConverter.UNIT_CLASS,
-                unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR
-                if meter["serviceType"] == "ELECTRIC"
-                else UnitOfVolume.CENTUM_CUBIC_FEET,
+                statistic_id=cost_statistic_id,
+                unit_class=None,
+                unit_of_measurement=None,
             )
-
             _LOGGER.debug(
                 "Adding %s statistics for %s",
-                len(consumption_statistics),
-                consumption_statistic_id,
+                len(cost_statistics),
+                cost_statistic_id,
             )
-            async_add_external_statistics(
-                self.hass, consumption_metadata, consumption_statistics
+            async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
+
+    def _build_statistic_rows(
+        self,
+        usage: dict[datetime, dict[str, float | int]],
+        consumption_baseline: tuple[float, float | None],
+        cost_baseline: tuple[float, float | None],
+        price_at: Callable[[datetime], float | None] | None,
+    ) -> tuple[list[StatisticData], list[StatisticData]]:
+        """
+        Build consumption and cost statistic rows from usage data.
+
+        Each baseline is the (sum, start time) to resume from. Consumption and
+        cost carry independent resume times so a cost statistic that lags
+        behind (price entity unavailable, or cost enabled after consumption
+        already existed) can catch up on later refreshes.
+        """
+        consumption_sum, last_stats_time = consumption_baseline
+        cost_sum, cost_last_stats_time = cost_baseline
+        consumption_statistics: list[StatisticData] = []
+        cost_statistics: list[StatisticData] = []
+        cost_incomplete = False
+
+        for start, data in usage.items():
+            energy = data["energy"]
+            if last_stats_time is None or start.timestamp() > last_stats_time:
+                consumption_sum += energy
+                consumption_statistics.append(
+                    StatisticData(start=start, state=energy, sum=consumption_sum)
+                )
+
+            if (
+                price_at is None
+                or cost_incomplete
+                or (
+                    cost_last_stats_time is not None
+                    and start.timestamp() <= cost_last_stats_time
+                )
+            ):
+                continue
+            price = price_at(start)
+            if price is None:
+                # Stop instead of skipping so the sum stays contiguous;
+                # the next refresh retries these hours.
+                cost_incomplete = True
+                _LOGGER.warning(
+                    "No price available for %s; deferring cost statistics", start
+                )
+                continue
+            cost_state = energy * price + self._hourly_fixed_charge(start)
+            cost_sum += cost_state
+            cost_statistics.append(
+                StatisticData(start=start, state=cost_state, sum=cost_sum)
             )
+
+        return consumption_statistics, cost_statistics
+
+    async def _async_get_cost_baseline(
+        self, cost_statistic_id: str, stats_in_window: list[Any] | None
+    ) -> tuple[float, float | None]:
+        """
+        Get the sum and start time to resume cost statistics from.
+
+        Prefer the oldest cost statistic within the current usage window so the
+        30-day lookback can rewrite recent hours with corrected data, mirroring
+        the consumption logic. If cost statistics exist only before the window
+        (e.g. the price entity was unavailable for a while), resume from the
+        newest one. If none exist at all, start from zero and backfill whatever
+        usage the window covers.
+        """
+        if stats_in_window:
+            return (
+                cast("float", stats_in_window[0]["sum"]),
+                stats_in_window[0]["start"],
+            )
+        last_cost_stat = await get_instance(self.hass).async_add_executor_job(
+            get_last_statistics,
+            self.hass,
+            1,
+            cost_statistic_id,
+            True,  # noqa: FBT003
+            {"sum"},
+        )
+        if last_cost_stat:
+            return (
+                cast("float", last_cost_stat[cost_statistic_id][0]["sum"]),
+                last_cost_stat[cost_statistic_id][0]["start"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            )
+        return 0.0, None
+
+    async def _async_build_price_lookup(
+        self, start: datetime, end: datetime
+    ) -> Callable[[datetime], float | None] | None:
+        """
+        Build a callable resolving the $/kWh price at a point in time.
+
+        Fixed mode returns a constant. Entity mode resolves prices from the
+        entity's long-term statistics (hourly mean) so time-of-use and
+        seasonal rates apply to backfilled hours, falling back to the entity's
+        current state for hours not covered by statistics.
+
+        Returns None if cost tracking is misconfigured.
+        """
+        options = self.config_entry.options
+        cost_mode = options.get(CONF_COST_MODE, COST_MODE_NONE)
+
+        if cost_mode == COST_MODE_FIXED:
+            fixed_price = options.get(CONF_FIXED_PRICE)
+            if not fixed_price:
+                _LOGGER.warning("Fixed cost mode is enabled but no price is set")
+                return None
+            return lambda _start: float(fixed_price)
+
+        if cost_mode == COST_MODE_ENTITY:
+            entity_id = options.get(CONF_PRICE_ENTITY)
+            if not entity_id:
+                _LOGGER.warning("Entity cost mode is enabled but no entity is set")
+                return None
+
+            current_price: float | None = None
+            state = self.hass.states.get(entity_id)
+            if state is not None and state.state not in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+            ):
+                try:
+                    current_price = float(state.state)
+                except ValueError:
+                    _LOGGER.warning(
+                        "Price entity %s has a non-numeric state: %s",
+                        entity_id,
+                        state.state,
+                    )
+
+            price_stats = await get_instance(self.hass).async_add_executor_job(
+                statistics_during_period,
+                self.hass,
+                start,
+                end + timedelta(hours=1),
+                {entity_id},
+                "hour",
+                None,
+                {"mean"},
+            )
+            price_rows = [
+                (row["start"], cast("float", row["mean"]))
+                for row in price_stats.get(entity_id, [])
+                if row.get("mean") is not None
+            ]
+            price_starts = [row[0] for row in price_rows]
+
+            def _lookup(point: datetime) -> float | None:
+                index = bisect_right(price_starts, point.timestamp()) - 1
+                if index >= 0:
+                    return price_rows[index][1]
+                if price_rows:
+                    # Before the entity's recorded history: use the earliest
+                    # known price rather than today's.
+                    return price_rows[0][1]
+                return current_price
+
+            return _lookup
+
+        return None
+
+    def _hourly_fixed_charge(self, start: datetime) -> float:
+        """Return the fixed monthly charge amortized over the hours of a month."""
+        monthly_charge = self.config_entry.options.get(CONF_MONTHLY_CHARGE)
+        if not monthly_charge:
+            return 0.0
+        days_in_month = calendar.monthrange(start.year, start.month)[1]
+        return float(monthly_charge) / (days_in_month * 24)
 
     async def _async_get_energy_usage(
         self, meter: dict[str, Any], start_time: float | None = None

--- a/custom_components/duke_energy/coordinator.py
+++ b/custom_components/duke_energy/coordinator.py
@@ -3,7 +3,7 @@
 import calendar
 import logging
 from bisect import bisect_right
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
 from typing import Any, cast
 
@@ -38,6 +38,7 @@ from homeassistant.util.unit_conversion import EnergyConverter
 from .const import (
     CONF_COST_MODE,
     CONF_FIXED_PRICE,
+    CONF_METERS,
     CONF_MONTHLY_CHARGE,
     CONF_PRICE_ENTITY,
     COST_MODE_ENTITY,
@@ -76,6 +77,8 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
         )
         self.api = api
         self._statistic_ids: set = set()
+        # Supported meters discovered on the last refresh, for the options flow.
+        self.meters: dict[str, dict[str, Any]] = {}
 
         @callback
         def _dummy_listener() -> None:
@@ -99,6 +102,7 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
         except DukeEnergyAuthError as err:
             raise ConfigEntryAuthFailed from err
 
+        self.meters = {}
         for serial_number, meter in meters.items():
             if (
                 not isinstance(meter["serviceType"], str)
@@ -109,6 +113,7 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
                 )
                 continue
 
+            self.meters[serial_number] = meter
             await self._async_insert_meter_statistics(serial_number, meter)
 
     async def _async_insert_meter_statistics(
@@ -118,44 +123,49 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
         id_prefix = f"{meter['serviceType'].lower()}_{serial_number}"
         consumption_statistic_id = f"{DOMAIN}:{id_prefix}_energy_consumption"
         cost_statistic_id = f"{DOMAIN}:{id_prefix}_energy_cost"
+        meter_options = self._meter_options(serial_number)
         cost_enabled = (
-            self.config_entry.options.get(CONF_COST_MODE, COST_MODE_NONE)
-            != COST_MODE_NONE
+            meter_options.get(CONF_COST_MODE, COST_MODE_NONE) != COST_MODE_NONE
         )
         self._statistic_ids.add(consumption_statistic_id)
         if cost_enabled:
             self._statistic_ids.add(cost_statistic_id)
-        _LOGGER.debug(
-            "Updating Statistics for %s",
-            consumption_statistic_id,
-        )
+        _LOGGER.debug("Updating Statistics for %s", consumption_statistic_id)
 
         statistic_ids = {consumption_statistic_id}
         if cost_enabled:
             statistic_ids.add(cost_statistic_id)
 
-        last_stat = await get_instance(self.hass).async_add_executor_job(
-            get_last_statistics,
-            self.hass,
-            1,
-            consumption_statistic_id,
-            True,  # noqa: FBT003
-            set(),
+        # Start time of each statistic's newest row; None means it has no
+        # history yet and must be backfilled from scratch.
+        consumption_resume = await self._async_last_stat_start(consumption_statistic_id)
+        cost_resume = (
+            await self._async_last_stat_start(cost_statistic_id)
+            if cost_enabled
+            else None
         )
+
+        # Fetch usage from the earliest resume point so a cost statistic that
+        # lagged behind consumption (e.g. the price entity was unavailable) has
+        # those hours re-fetched and can catch up instead of stalling forever.
+        resume_points = [consumption_resume]
+        if cost_enabled:
+            resume_points.append(cost_resume)
+        window_from = (
+            None
+            if None in resume_points
+            else min(point for point in resume_points if point is not None)
+        )
+
+        usage = await self._async_get_energy_usage(meter, window_from)
+        if window_from is not None and not usage:
+            _LOGGER.debug("No recent usage data. Skipping update")
+            return
+
         # Each baseline is the (sum, start time) to resume statistics from.
+        consumption_baseline: tuple[float, float | None] = (0.0, None)
         cost_baseline: tuple[float, float | None] = (0.0, None)
-        if not last_stat:
-            _LOGGER.debug("Updating statistic for the first time")
-            usage = await self._async_get_energy_usage(meter)
-            consumption_baseline: tuple[float, float | None] = (0.0, None)
-        else:
-            usage = await self._async_get_energy_usage(
-                meter,
-                last_stat[consumption_statistic_id][0]["start"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
-            )
-            if not usage:
-                _LOGGER.debug("No recent usage data. Skipping update")
-                return
+        if window_from is not None:
             stats = await get_instance(self.hass).async_add_executor_job(
                 statistics_during_period,
                 self.hass,
@@ -166,26 +176,20 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
                 None,
                 {"sum"},
             )
-            consumption_baseline = (
-                cast(
-                    "float",
-                    stats[consumption_statistic_id][0]["sum"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
-                ),
-                stats[consumption_statistic_id][0]["start"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            consumption_baseline = self._resume_baseline(
+                stats.get(consumption_statistic_id)
             )
             if cost_enabled:
-                cost_baseline = await self._async_get_cost_baseline(
-                    cost_statistic_id, stats.get(cost_statistic_id)
-                )
+                cost_baseline = self._resume_baseline(stats.get(cost_statistic_id))
 
         price_at: Callable[[datetime], float | None] | None = None
         if cost_enabled and usage:
             price_at = await self._async_build_price_lookup(
-                min(usage.keys()), max(usage.keys())
+                meter_options, min(usage.keys()), max(usage.keys())
             )
 
         consumption_statistics, cost_statistics = self._build_statistic_rows(
-            usage, consumption_baseline, cost_baseline, price_at
+            usage, consumption_baseline, cost_baseline, price_at, meter_options
         )
 
         name_prefix = f"Duke Energy {meter['serviceType'].capitalize()} {serial_number}"
@@ -233,6 +237,7 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
         consumption_baseline: tuple[float, float | None],
         cost_baseline: tuple[float, float | None],
         price_at: Callable[[datetime], float | None] | None,
+        meter_options: Mapping[str, Any],
     ) -> tuple[list[StatisticData], list[StatisticData]]:
         """
         Build consumption and cost statistic rows from usage data.
@@ -274,7 +279,9 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
                     "No price available for %s; deferring cost statistics", start
                 )
                 continue
-            cost_state = energy * price + self._hourly_fixed_charge(start)
+            cost_state = energy * price + self._hourly_fixed_charge(
+                meter_options, start
+            )
             cost_sum += cost_state
             cost_statistics.append(
                 StatisticData(start=start, state=cost_state, sum=cost_sum)
@@ -282,41 +289,49 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
 
         return consumption_statistics, cost_statistics
 
-    async def _async_get_cost_baseline(
-        self, cost_statistic_id: str, stats_in_window: list[Any] | None
-    ) -> tuple[float, float | None]:
-        """
-        Get the sum and start time to resume cost statistics from.
-
-        Prefer the oldest cost statistic within the current usage window so the
-        30-day lookback can rewrite recent hours with corrected data, mirroring
-        the consumption logic. If cost statistics exist only before the window
-        (e.g. the price entity was unavailable for a while), resume from the
-        newest one. If none exist at all, start from zero and backfill whatever
-        usage the window covers.
-        """
-        if stats_in_window:
-            return (
-                cast("float", stats_in_window[0]["sum"]),
-                stats_in_window[0]["start"],
-            )
-        last_cost_stat = await get_instance(self.hass).async_add_executor_job(
+    async def _async_last_stat_start(self, statistic_id: str) -> float | None:
+        """Return the start time of a statistic's newest row, or None if empty."""
+        last_stat = await get_instance(self.hass).async_add_executor_job(
             get_last_statistics,
             self.hass,
             1,
-            cost_statistic_id,
+            statistic_id,
             True,  # noqa: FBT003
-            {"sum"},
+            set(),
         )
-        if last_cost_stat:
-            return (
-                cast("float", last_cost_stat[cost_statistic_id][0]["sum"]),
-                last_cost_stat[cost_statistic_id][0]["start"],  # pyright: ignore[reportTypedDictNotRequiredAccess]
-            )
+        if last_stat:
+            return last_stat[statistic_id][0]["start"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        return None
+
+    @staticmethod
+    def _resume_baseline(rows: list[Any] | None) -> tuple[float, float | None]:
+        """
+        Return the (sum, start) to resume from: the oldest row in the window.
+
+        Resuming from the window start lets the 30-day usage lookback rewrite
+        recently corrected hours while keeping the running sum contiguous.
+        """
+        if rows:
+            return cast("float", rows[0]["sum"]), rows[0]["start"]
         return 0.0, None
 
+    def _meter_options(self, serial_number: str) -> Mapping[str, Any]:
+        """
+        Return a meter's cost options.
+
+        Falls back to the pre-per-meter flat options so entries configured
+        before per-meter pricing keep working until reconfigured.
+        """
+        meters = self.config_entry.options.get(CONF_METERS)
+        if meters is None:
+            return self.config_entry.options
+        return meters.get(serial_number, {})
+
     async def _async_build_price_lookup(
-        self, start: datetime, end: datetime
+        self,
+        meter_options: Mapping[str, Any],
+        start: datetime,
+        end: datetime,
     ) -> Callable[[datetime], float | None] | None:
         """
         Build a callable resolving the $/kWh price at a point in time.
@@ -328,18 +343,17 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
 
         Returns None if cost tracking is misconfigured.
         """
-        options = self.config_entry.options
-        cost_mode = options.get(CONF_COST_MODE, COST_MODE_NONE)
+        cost_mode = meter_options.get(CONF_COST_MODE, COST_MODE_NONE)
 
         if cost_mode == COST_MODE_FIXED:
-            fixed_price = options.get(CONF_FIXED_PRICE)
+            fixed_price = meter_options.get(CONF_FIXED_PRICE)
             if not fixed_price:
                 _LOGGER.warning("Fixed cost mode is enabled but no price is set")
                 return None
             return lambda _start: float(fixed_price)
 
         if cost_mode == COST_MODE_ENTITY:
-            entity_id = options.get(CONF_PRICE_ENTITY)
+            entity_id = meter_options.get(CONF_PRICE_ENTITY)
             if not entity_id:
                 _LOGGER.warning("Entity cost mode is enabled but no entity is set")
                 return None
@@ -390,9 +404,11 @@ class DukeEnergyCoordinator(DataUpdateCoordinator[None]):
 
         return None
 
-    def _hourly_fixed_charge(self, start: datetime) -> float:
+    def _hourly_fixed_charge(
+        self, meter_options: Mapping[str, Any], start: datetime
+    ) -> float:
         """Return the fixed monthly charge amortized over the hours of a month."""
-        monthly_charge = self.config_entry.options.get(CONF_MONTHLY_CHARGE)
+        monthly_charge = meter_options.get(CONF_MONTHLY_CHARGE)
         if not monthly_charge:
             return 0.0
         days_in_month = calendar.monthrange(start.year, start.month)[1]

--- a/custom_components/duke_energy/strings.json
+++ b/custom_components/duke_energy/strings.json
@@ -28,5 +28,38 @@
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Energy cost tracking",
+        "description": "Publish a cost statistic alongside consumption for the Energy dashboard. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
+        "data": {
+          "cost_mode": "Price source",
+          "fixed_price": "Price per kWh",
+          "price_entity": "Price entity",
+          "monthly_charge": "Fixed monthly charge"
+        },
+        "data_description": {
+          "cost_mode": "Where the $/kWh price comes from.",
+          "fixed_price": "Used when the price source is a fixed price.",
+          "price_entity": "An entity whose state is the current price in $/kWh (e.g. an input number or a template sensor for time-of-use rates). Used when the price source is an entity.",
+          "monthly_charge": "Optional flat monthly service charge in $, spread evenly across the hours of each month."
+        }
+      }
+    },
+    "error": {
+      "fixed_price_required": "Enter a price per kWh to use fixed pricing.",
+      "price_entity_required": "Select an entity that provides the price per kWh."
+    }
+  },
+  "selector": {
+    "cost_mode": {
+      "options": {
+        "none": "Disabled",
+        "fixed": "Fixed price per kWh",
+        "entity": "Track a price entity ($/kWh)"
+      }
+    }
   }
 }

--- a/custom_components/duke_energy/strings.json
+++ b/custom_components/duke_energy/strings.json
@@ -32,8 +32,15 @@
   "options": {
     "step": {
       "init": {
+        "title": "Select a meter",
+        "description": "Choose which meter's cost tracking to configure. Each meter can use its own price.",
+        "data": {
+          "meter": "Meter"
+        }
+      },
+      "meter": {
         "title": "Energy cost tracking",
-        "description": "Publish a cost statistic alongside consumption for the Energy dashboard. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
+        "description": "Publish a cost statistic alongside consumption for {meter}. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
         "data": {
           "cost_mode": "Price source",
           "fixed_price": "Price per kWh",
@@ -47,6 +54,9 @@
           "monthly_charge": "Optional flat monthly service charge in $, spread evenly across the hours of each month."
         }
       }
+    },
+    "abort": {
+      "no_meters": "No supported meters were found to configure."
     },
     "error": {
       "fixed_price_required": "Enter a price per kWh to use fixed pricing.",

--- a/custom_components/duke_energy/strings.json
+++ b/custom_components/duke_energy/strings.json
@@ -43,14 +43,14 @@
         "description": "Publish a cost statistic alongside consumption for {meter}. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
         "data": {
           "cost_mode": "Price source",
-          "fixed_price": "Price per kWh",
+          "fixed_price": "Fixed price",
           "price_entity": "Price entity",
           "monthly_charge": "Fixed monthly charge"
         },
         "data_description": {
-          "cost_mode": "Where the $/kWh price comes from.",
-          "fixed_price": "Used when the price source is a fixed price.",
-          "price_entity": "An entity whose state is the current price in $/kWh (e.g. an input number or a template sensor for time-of-use rates). Used when the price source is an entity.",
+          "cost_mode": "Where the price per {unit} comes from.",
+          "fixed_price": "A single all-in price per {unit}.",
+          "price_entity": "An entity whose state is the current price per {unit} (e.g. an input number, or a template sensor for time-of-use rates).",
           "monthly_charge": "Optional flat monthly service charge in $, spread evenly across the hours of each month."
         }
       }
@@ -67,8 +67,8 @@
     "cost_mode": {
       "options": {
         "none": "Disabled",
-        "fixed": "Fixed price per kWh",
-        "entity": "Track a price entity ($/kWh)"
+        "fixed": "Fixed price",
+        "entity": "Track a price entity"
       }
     }
   }

--- a/custom_components/duke_energy/translations/en.json
+++ b/custom_components/duke_energy/translations/en.json
@@ -28,5 +28,38 @@
                 "title": "Authentication expired for {name}"
             }
         }
+    },
+    "options": {
+        "error": {
+            "fixed_price_required": "Enter a price per kWh to use fixed pricing.",
+            "price_entity_required": "Select an entity that provides the price per kWh."
+        },
+        "step": {
+            "init": {
+                "data": {
+                    "cost_mode": "Price source",
+                    "fixed_price": "Price per kWh",
+                    "monthly_charge": "Fixed monthly charge",
+                    "price_entity": "Price entity"
+                },
+                "data_description": {
+                    "cost_mode": "Where the $/kWh price comes from.",
+                    "fixed_price": "Used when the price source is a fixed price.",
+                    "monthly_charge": "Optional flat monthly service charge in $, spread evenly across the hours of each month.",
+                    "price_entity": "An entity whose state is the current price in $/kWh (e.g. an input number or a template sensor for time-of-use rates). Used when the price source is an entity."
+                },
+                "description": "Publish a cost statistic alongside consumption for the Energy dashboard. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
+                "title": "Energy cost tracking"
+            }
+        }
+    },
+    "selector": {
+        "cost_mode": {
+            "options": {
+                "entity": "Track a price entity ($/kWh)",
+                "fixed": "Fixed price per kWh",
+                "none": "Disabled"
+            }
+        }
     }
 }

--- a/custom_components/duke_energy/translations/en.json
+++ b/custom_components/duke_energy/translations/en.json
@@ -48,15 +48,15 @@
             "meter": {
                 "data": {
                     "cost_mode": "Price source",
-                    "fixed_price": "Price per kWh",
+                    "fixed_price": "Fixed price",
                     "monthly_charge": "Fixed monthly charge",
                     "price_entity": "Price entity"
                 },
                 "data_description": {
-                    "cost_mode": "Where the $/kWh price comes from.",
-                    "fixed_price": "Used when the price source is a fixed price.",
+                    "cost_mode": "Where the price per {unit} comes from.",
+                    "fixed_price": "A single all-in price per {unit}.",
                     "monthly_charge": "Optional flat monthly service charge in $, spread evenly across the hours of each month.",
-                    "price_entity": "An entity whose state is the current price in $/kWh (e.g. an input number or a template sensor for time-of-use rates). Used when the price source is an entity."
+                    "price_entity": "An entity whose state is the current price per {unit} (e.g. an input number, or a template sensor for time-of-use rates)."
                 },
                 "description": "Publish a cost statistic alongside consumption for {meter}. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
                 "title": "Energy cost tracking"
@@ -66,8 +66,8 @@
     "selector": {
         "cost_mode": {
             "options": {
-                "entity": "Track a price entity ($/kWh)",
-                "fixed": "Fixed price per kWh",
+                "entity": "Track a price entity",
+                "fixed": "Fixed price",
                 "none": "Disabled"
             }
         }

--- a/custom_components/duke_energy/translations/en.json
+++ b/custom_components/duke_energy/translations/en.json
@@ -30,12 +30,22 @@
         }
     },
     "options": {
+        "abort": {
+            "no_meters": "No supported meters were found to configure."
+        },
         "error": {
             "fixed_price_required": "Enter a price per kWh to use fixed pricing.",
             "price_entity_required": "Select an entity that provides the price per kWh."
         },
         "step": {
             "init": {
+                "data": {
+                    "meter": "Meter"
+                },
+                "description": "Choose which meter's cost tracking to configure. Each meter can use its own price.",
+                "title": "Select a meter"
+            },
+            "meter": {
                 "data": {
                     "cost_mode": "Price source",
                     "fixed_price": "Price per kWh",
@@ -48,7 +58,7 @@
                     "monthly_charge": "Optional flat monthly service charge in $, spread evenly across the hours of each month.",
                     "price_entity": "An entity whose state is the current price in $/kWh (e.g. an input number or a template sensor for time-of-use rates). Used when the price source is an entity."
                 },
-                "description": "Publish a cost statistic alongside consumption for the Energy dashboard. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
+                "description": "Publish a cost statistic alongside consumption for {meter}. Duke Energy does not expose billed cost, so cost is estimated from usage and a price you provide.",
                 "title": "Energy cost tracking"
             }
         }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.4.2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Duke Energy integration."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,92 @@
+"""Unit tests for the pure statistic builders in the coordinator.
+
+These exercise the price/consumption math directly, bypassing Home Assistant so
+they need no recorder or event loop.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from custom_components.duke_energy.const import CONF_MONTHLY_CHARGE
+from custom_components.duke_energy.coordinator import DukeEnergyCoordinator
+
+NY = ZoneInfo("America/New_York")
+
+
+def test_build_consumption_rows_cumulative_and_resume() -> None:
+    """Consumption sums accumulate, and resuming skips already-recorded hours."""
+    energy = {datetime(2025, 7, 1, h): float(h) for h in range(1, 4)}  # 1, 2, 3
+
+    rows = DukeEnergyCoordinator._build_consumption_rows(energy, (0.0, None))
+    assert [r["state"] for r in rows] == [1.0, 2.0, 3.0]
+    assert [r["sum"] for r in rows] == [1.0, 3.0, 6.0]
+
+    resume = datetime(2025, 7, 1, 1).timestamp()
+    rows = DukeEnergyCoordinator._build_consumption_rows(energy, (1.0, resume))
+    assert [r["state"] for r in rows] == [2.0, 3.0]
+    assert [r["sum"] for r in rows] == [3.0, 6.0]
+
+
+def test_build_cost_rows_fixed_price() -> None:
+    """A flat price yields energy * price cumulative sums."""
+    coord = object.__new__(DukeEnergyCoordinator)
+    energy = {datetime(2025, 7, 1, h): float(h) for h in range(1, 4)}
+
+    rows = coord._build_cost_rows(energy, (0.0, None), lambda _s: 0.10, {})
+    assert [round(r["sum"], 3) for r in rows] == [0.1, 0.3, 0.6]
+
+
+def test_build_cost_rows_defers_on_missing_price() -> None:
+    """Cost stops at the first unpriced hour so the running sum stays contiguous."""
+    coord = object.__new__(DukeEnergyCoordinator)
+    energy = {datetime(2025, 7, 1, h): 1.0 for h in range(3)}
+    prices = {0: 0.10, 1: None, 2: 0.10}
+
+    rows = coord._build_cost_rows(energy, (0.0, None), lambda s: prices[s.hour], {})
+    assert len(rows) == 1
+    assert rows[0]["start"].hour == 0
+
+
+def test_build_cost_rows_includes_monthly_charge() -> None:
+    """The fixed monthly charge is amortized across the hours of the month."""
+    coord = object.__new__(DukeEnergyCoordinator)
+    energy = {datetime(2025, 7, 1, 0): 0.0}  # July spans 744 hours
+
+    rows = coord._build_cost_rows(
+        energy, (0.0, None), lambda _s: 0.0, {CONF_MONTHLY_CHARGE: 31}
+    )
+    assert round(rows[0]["state"], 6) == round(31 / 744, 6)
+
+
+def test_resume_baseline_anchors_to_lookback() -> None:
+    """Resume anchors ~30 days before the newest row, not the window start."""
+    base = datetime(2025, 6, 1, tzinfo=NY).timestamp()
+    rows = [{"start": base + i * 3600, "sum": float(i)} for i in range(40 * 24)]
+    resume = rows[-1]["start"]
+
+    total, start = DukeEnergyCoordinator._resume_baseline(rows, resume)
+    assert start == resume - 30 * 86400
+    assert total == next(r["sum"] for r in rows if r["start"] == start)
+
+
+def test_resume_baseline_without_history() -> None:
+    """No rows or no resume point means start from zero."""
+    assert DukeEnergyCoordinator._resume_baseline(None, 123.0) == (0.0, None)
+    assert DukeEnergyCoordinator._resume_baseline(
+        [{"start": 1.0, "sum": 5.0}], None
+    ) == (0.0, None)
+
+
+def test_hourly_fixed_charge_is_dst_aware() -> None:
+    """Amortization uses the real hours in a month, including DST transitions."""
+    coord = object.__new__(DukeEnergyCoordinator)
+    opts = {CONF_MONTHLY_CHARGE: 30}
+
+    naive_july = coord._hourly_fixed_charge(opts, datetime(2025, 7, 15))
+    assert round(naive_july, 8) == round(30 / (31 * 24), 8)
+
+    march = coord._hourly_fixed_charge(opts, datetime(2025, 3, 15, tzinfo=NY))
+    assert round(march, 8) == round(30 / 743, 8)  # spring forward: 743 hours
+
+    november = coord._hourly_fixed_charge(opts, datetime(2025, 11, 15, tzinfo=NY))
+    assert round(november, 8) == round(30 / 721, 8)  # fall back: 721 hours


### PR DESCRIPTION
Closes #53

## What

Adds an opower-style external cost statistic per electric meter — `duke_energy:electric_<serial>_energy_cost` — inserted alongside the existing consumption statistic, so the Energy dashboard can track $ via **"Use an entity tracking the total costs"** on the grid source.

As established in the #53 discussion, the CMA API exposes no per-interval cost (`usageArray` only carries `usage`/`temperatureAvg`), so cost is derived from consumption using a user-configured price source. A new **Configure** (options) dialog offers:

- **Fixed price per kWh** — a single all-in rate.
- **Price entity (dynamic)** — an entity whose state is the current $/kWh (an `input_number` for a flat rate, or a template sensor for time-of-use/seasonal rates — the superset approach from the issue thread). Backfilled hours are priced from the entity's **long-term statistics** (hourly mean) when available, so TOU rates apply correctly to historical hours; hours without recorded history fall back to the entity's current state.
- **Optional fixed monthly charge**, amortized evenly across each month's hours.

## How

- `coordinator.py` mirrors the consumption path exactly as proposed in the issue: seed `cost_sum` from `get_last_statistics`/`statistics_during_period`, append `StatisticData(start, state, sum)` rows, insert with `async_add_external_statistics` using `unit_class=None` / `unit_of_measurement=None` (same as core `opower`).
- The cost statistic keeps its **own resume point**, independent of consumption, so it can lag and catch up on later refreshes (price entity temporarily unavailable, or cost enabled after consumption history already exists). If a price can't be resolved for an hour, cost insertion stops at that hour (keeping sums contiguous) and retries next refresh.
- Options changes reload the entry. Since the coordinator already clears its statistics on unload and rebuilds from scratch on setup, changing the price settings recomputes the full (~3-year) cost history automatically.
- `config_flow.py` gains an `OptionsFlowHandler` with selectors and validation; strings/en translations and README documentation included.

## Testing

- `ruff format --check` / `ruff check` (repo config, `ALL` rules) pass.
- Modules import cleanly against `homeassistant==2025.12.5`; verified `StatisticMetaData`, `statistics_during_period`, and `get_last_statistics` signatures.
- Behavioral checks on the row builder: fixed-price sums, monthly-charge amortization (July: `30 / (31×24)` per hour), independent cost catch-up when cost lags consumption, deferral on missing price, and consumption unaffected by cost misconfiguration.
- @jojobird6 testing this branch currently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
